### PR TITLE
Fix includes

### DIFF
--- a/parameter_estimation/src/bt_bounds.c
+++ b/parameter_estimation/src/bt_bounds.c
@@ -15,9 +15,8 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <stdio.h>
-#include <stdlib.h>
 #include "bt_bounds.h"
+#include <stdlib.h>
 
 #define str(x) #x
 #define expand(x) str(x)

--- a/parameter_estimation/src/bt_bounds.h
+++ b/parameter_estimation/src/bt_bounds.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include "bt_model.h"
+#include <stdio.h>
 
 /**
  * The bounds of the design variables for initial population generation and the

--- a/parameter_estimation/src/bt_data.c
+++ b/parameter_estimation/src/bt_data.c
@@ -15,10 +15,9 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <stdio.h>
+#include "bt_data.h"
 #include <stdlib.h>
 #include <string.h>
-#include "bt_data.h"
 
 
 static int bt_data_parse_line(const char *line, bt_data_t *data) {

--- a/parameter_estimation/src/bt_data.h
+++ b/parameter_estimation/src/bt_data.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <stdio.h>
+
 /**
  * Represents the training data.
  *

--- a/parameter_estimation/src/bt_model.c
+++ b/parameter_estimation/src/bt_model.c
@@ -15,12 +15,10 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <stdio.h>
+#include "bt_model.h"
 #include <math.h>
-#include <stdio.h>
 #include <string.h>
 #include <strings.h>
-#include "bt_model.h"
 
 
 const char *bt_design_var_names[DESIGN_VAR_COUNT] = {

--- a/parameter_estimation/src/bt_model.h
+++ b/parameter_estimation/src/bt_model.h
@@ -26,6 +26,7 @@
 #include "bt_data.h"
 #include "bt_trials.h"
 #include "ga.h"
+#include <stdio.h>
 
 /**
  * Count of design variables.

--- a/parameter_estimation/src/bt_trials.c
+++ b/parameter_estimation/src/bt_trials.c
@@ -15,10 +15,9 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <stdio.h>
+#include "bt_trials.h"
 #include <stdlib.h>
 #include <string.h>
-#include "bt_trials.h"
 
 
 static int bt_trials_parse_line(const char *line, bt_trials_t *trials) {

--- a/parameter_estimation/src/bt_trials.h
+++ b/parameter_estimation/src/bt_trials.h
@@ -23,6 +23,8 @@
 
 #pragma once
 
+#include <stdio.h>
+
 /**
  * The indices of the performance values within the training data that should
  * be fit during optimization.

--- a/parameter_estimation/src/ga.c
+++ b/parameter_estimation/src/ga.c
@@ -15,14 +15,12 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <assert.h>
-#include <float.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include "ga.h"
 #include "randomkit.h"
 #include "stats.h"
+#include <assert.h>
+#include <stdlib.h>
+#include <string.h>
 
 
 void init_random_population(const size_t nmemb, const size_t design_var_count,

--- a/parameter_estimation/src/ga.h
+++ b/parameter_estimation/src/ga.h
@@ -24,6 +24,7 @@
 #pragma once
 
 #include "randomkit.h"
+#include <stdio.h>
 
 /**
  * Type of design variable values.

--- a/parameter_estimation/src/main.c
+++ b/parameter_estimation/src/main.c
@@ -15,12 +15,6 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <getopt.h>
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include "bt_bounds.h"
 #include "bt_data.h"
 #include "bt_trials.h"
@@ -28,6 +22,12 @@
 #include "ga.h"
 #include "randomkit.h"
 #include "stats.h"
+#include <getopt.h>
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 
 #define MAX_PATH_LENGTH 1000

--- a/parameter_estimation/src/stats.c
+++ b/parameter_estimation/src/stats.c
@@ -15,9 +15,9 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
+#include "stats.h"
 #include <math.h>
 #include <stdlib.h>
-#include "stats.h"
 
 static int compare_doubles(const void *first, const void *second)
 {

--- a/parameter_estimation/src/test.c
+++ b/parameter_estimation/src/test.c
@@ -15,11 +15,11 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
+#include "stats.h"
 #include <assert.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include "stats.h"
 
 bool approx_eq(const double a, const double b, const double eps)
 {

--- a/training_optimization/src/args.c
+++ b/training_optimization/src/args.c
@@ -15,12 +15,10 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <getopt.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include "bt_model.h"
 #include "args.h"
+#include "bt_model.h"
+#include <getopt.h>
+#include <stdlib.h>
 
 
 void usage(const char *program_name)

--- a/training_optimization/src/args.h
+++ b/training_optimization/src/args.h
@@ -23,6 +23,9 @@
 
 #pragma once
 
+#include <stdbool.h>
+#include <stdio.h>
+
 /**
  * Command line arguments.
  */

--- a/training_optimization/src/bt_constraints.h
+++ b/training_optimization/src/bt_constraints.h
@@ -29,6 +29,7 @@
 #pragma once
 
 #include "bt_population.h"
+#include <stdio.h>
 
 /**
  * Updates the penalty value.

--- a/training_optimization/src/bt_ga.c
+++ b/training_optimization/src/bt_ga.c
@@ -15,14 +15,13 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
+#include "bt_ga.h"
+#include "bt_model.h"
+#include "stats.h"
 #include <assert.h>
-#include <float.h>
 #include <math.h>
 #include <stdlib.h>
 #include <string.h>
-#include "bt_model.h"
-#include "bt_ga.h"
-#include "stats.h"
 
 
 void ga_init_stresses(const size_t nmemb, const size_t num_days,

--- a/training_optimization/src/bt_model.c
+++ b/training_optimization/src/bt_model.c
@@ -15,14 +15,9 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <assert.h>
-#include <stdio.h>
-#include <math.h>
-#include <stdio.h>
-#include <string.h>
-#include <strings.h>
-#include "bt_constraints.h"
 #include "bt_model.h"
+#include "bt_constraints.h"
+#include <math.h>
 
 
 #define DAY_LENGTH 1

--- a/training_optimization/src/bt_model.h
+++ b/training_optimization/src/bt_model.h
@@ -25,6 +25,7 @@
 
 #include "bt_params.h"
 #include "bt_population.h"
+#include <stdio.h>
 
 /**
  * Writes the result of integrating the nonlinear model.

--- a/training_optimization/src/bt_params.c
+++ b/training_optimization/src/bt_params.c
@@ -15,10 +15,10 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
+#include "bt_params.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "bt_params.h"
 
 
 /**

--- a/training_optimization/src/bt_population.c
+++ b/training_optimization/src/bt_population.c
@@ -15,10 +15,10 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <stdlib.h>
-#include <string.h>
 #include "bt_population.h"
 #include "stats.h"
+#include <stdlib.h>
+#include <string.h>
 
 
 bt_population_t *bt_population_alloc(const size_t nmemb, const size_t num_days)

--- a/training_optimization/src/bt_population.h
+++ b/training_optimization/src/bt_population.h
@@ -23,7 +23,6 @@
 
 #pragma once
 
-#include <stdbool.h>
 #include <stdio.h>
 
 /**

--- a/training_optimization/src/main.c
+++ b/training_optimization/src/main.c
@@ -15,18 +15,16 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
-#include <assert.h>
-#include <float.h>
-#include <stdbool.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include "args.h"
 #include "bt_model.h"
 #include "bt_params.h"
 #include "bt_population.h"
 #include "bt_ga.h"
 #include "stats.h"
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 
 #define MAX_PATH_LENGTH 1000

--- a/training_optimization/src/stats.c
+++ b/training_optimization/src/stats.c
@@ -15,9 +15,9 @@
  * <https://www.gnu.org/licenses/old-licenses/gpl-2.0.txt>.
  */
 
+#include "stats.h"
 #include <math.h>
 #include <stdlib.h>
-#include "stats.h"
 
 static int compare_doubles(const void *first, const void *second)
 {


### PR DESCRIPTION
This moves the include of the header corresponding to the .c file to the top of the include list (and other header files from this project just below that). This follows the LLVM coding standard and helps avoid missing dependencies in header files.